### PR TITLE
fix(deps): patch brace-expansion (CVE-2026-13149, GHSA-mh99-v99m-4gvg)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7712,9 +7712,9 @@
       }
     },
     "node_modules/@redocly/openapi-core/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -10023,9 +10023,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -14425,15 +14425,15 @@
       }
     },
     "node_modules/graphql-config/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/graphql-config/node_modules/jiti": {


### PR DESCRIPTION
`main` is still on `brace-expansion@1.1.15`, which carries CVE-2026-13149 and GHSA-mh99-v99m-4gvg.

Dependabot opened this as #129 on 08-04, then closed it on 08-07 at 12:23:47Z when merging #128 shifted the lockfile out from under it. It has not reopened, and it cannot — its runs on repos in this org fail with `ERR_PNPM_FETCH_401` against `npm.pkg.github.com`. So the patch needs a manual push.

## Changes

Lockfile only. Three ranges move, matching what #129 intended:

- `1.1.15` -> `1.1.18`
- `2.1.1` -> `2.1.4`
- `5.0.7` -> `5.0.9`

## Verification

- `git status` shows `package-lock.json` and nothing else.
- The 5 nested `prettier@3.8.3` entries that graphiql v5 needs are still present — that is the thing dependabot's own regeneration keeps deleting, and what made #128/#130/#131 fail `npm ci` with EUSAGE.
- `npm ci` and `npm run build` both pass locally.
